### PR TITLE
Add loved status enum

### DIFF
--- a/osuapi/enums.py
+++ b/osuapi/enums.py
@@ -130,6 +130,7 @@ class BeatmapStatus(Enum):
     ranked = 1
     approved = 2
     qualified = 3
+    loved = 4
 
 
 class BeatmapGenre(Enum):


### PR DESCRIPTION
As described [here](https://github.com/ppy/osu-api/wiki):
> "approved"         : "1",                   // 4 = loved, 3 = qualified, 2 = approved, 1 = ranked, 0 = pending, -1 = WIP, -2 = graveyard

Currently we have everything but the loved.