### PR TITLE
Add event_days kwarg to get_user and convert events to dicts

### DIFF
--- a/osuapi/model.py
+++ b/osuapi/model.py
@@ -201,8 +201,8 @@ class User(AttributeModel):
         Country the user is registered to.
     pp_country_rank : int
         Country ranking place.
-    events : list[str]
-        HTML snippets of recent "interesting" events.
+    events : list[dict]
+        Information about recent "interesting" events.
 
     See Also
     ---------
@@ -226,7 +226,7 @@ class User(AttributeModel):
     count_rank_a = Attribute(Nullable(int))
     country = Attribute(str)
     pp_country_rank = Attribute(int)
-    events = Attribute(JsonList(str))
+    events = Attribute(JsonList(dict))
 
     @property
     def total_hits(self):


### PR DESCRIPTION
Makes it a bit easier to work with user events. 

I had some test errors, but I'm not sure if I caused them myself:

```
....EE
======================================================================
ERROR: test_get_user_recent (osuapi_test.OsuApiTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/degraafc/code/osuapi/test/osuapi_test.py", line 41, in test_get_user_recent
    for k, v in dict(res[0]).items():
IndexError: list index out of range
-------------------- >> begin captured logging << --------------------
urllib3.connectionpool: DEBUG: Starting new HTTPS connection (1): osu.ppy.sh
urllib3.connectionpool: DEBUG: https://osu.ppy.sh:443 "GET /api/get_user_recent?k=#####&u=khazhyk&type=string&m=0&limit=10 HTTP/1.1" 200 None
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: osuapi_test.async_test
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
TypeError: async_test() missing 1 required positional argument: 'f'

----------------------------------------------------------------------
Ran 6 tests in 4.866s

FAILED (errors=2)
Exception ignored in: <ssl.SSLSocket fd=4, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 34392), raddr=('104.20.51.28', 443)>
ResourceWarning: unclosed <ssl.SSLSocket fd=4, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 34392), raddr=('104.20.51.28', 443)>
Exception ignored in: <ssl.SSLSocket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 41390), raddr=('104.20.52.28', 443)>
ResourceWarning: unclosed <ssl.SSLSocket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 41390), raddr=('104.20.52.28', 443)>
Exception ignored in: <ssl.SSLSocket fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 34396), raddr=('104.20.51.28', 443)>
ResourceWarning: unclosed <ssl.SSLSocket fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 34396), raddr=('104.20.51.28', 443)>
Exception ignored in: <ssl.SSLSocket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 41394), raddr=('104.20.52.28', 443)>
ResourceWarning: unclosed <ssl.SSLSocket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 41394), raddr=('104.20.52.28', 443)>
Exception ignored in: <ssl.SSLSocket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 41386), raddr=('104.20.52.28', 443)>
ResourceWarning: unclosed <ssl.SSLSocket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('192.168.0.8', 41386), raddr=('104.20.52.28', 443)>
```