### PR TITLE
Make pp nullable in SoloScore and BeatmapScore

### DIFF
--- a/osuapi/model.py
+++ b/osuapi/model.py
@@ -110,8 +110,8 @@ class SoloScore(Score):
     -----------
     beatmap_id : int
         Beatmap the score is for.
-    pp : float
-        How much PP the score is worth
+    pp : Optional[float]
+        How much PP the score is worth, or None if not eligible for PP.
     enabled_mods : :class:`osuapi.enums.OsuMod`
         Enabled modifiers
     date : datetime
@@ -122,7 +122,7 @@ class SoloScore(Score):
     <https://osu.ppy.sh/wiki/Score>
     """
     beatmap_id = Attribute(str)
-    pp = Attribute(float)
+    pp = Attribute(Nullable(float))
     enabled_mods = Attribute(PreProcessInt(OsuMod))
     date = Attribute(DateConverter)
 
@@ -139,8 +139,8 @@ class BeatmapScore(Score):
     -----------
     username : str
         Name of user.
-    pp : float
-        How much PP the score is worth
+    pp : Optional[float]
+        How much PP the score is worth, or None if not eligible for PP.
     enabled_mods : :class:`osuapi.enums.OsuMod`
         Enabled modifiers
     date : datetime
@@ -153,7 +153,7 @@ class BeatmapScore(Score):
     <https://osu.ppy.sh/wiki/Score>
     """
     username = Attribute(str)
-    pp = Attribute(float)
+    pp = Attribute(Nullable(float))
     enabled_mods = Attribute(PreProcessInt(OsuMod))
     date = Attribute(DateConverter)
     score_id = Attribute(int)

--- a/osuapi/osu.py
+++ b/osuapi/osu.py
@@ -112,7 +112,7 @@ class OsuApi:
             u=username,
             type=_username_type(username),
             m=mode.value,
-            mods=mods and mods.value,
+            mods=mods.value if mods else None,
             limit=limit), JsonList(BeatmapScore))
 
     def get_beatmaps(self, *, since=None, beatmapset_id=None, beatmap_id=None, username=None, mode=OsuMode.osu,


### PR DESCRIPTION
Fixes this, on Loved maps:

```
In [3]: api.get_scores(b_id, mode=osuapi.OsuMode.mania)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-4358c7590dc1> in <module>()
----> 1 osubot.consts.osu_api.get_scores(b_id, mode=osuapi.OsuMode.mania)

~/code/api/osuapi/osu.py in get_scores(self, beatmap_id, username, mode, mods, limit)
    114             m=mode.value,
    115             mods=mods.value if mods else None,
--> 116             limit=limit), JsonList(BeatmapScore))
    117 
    118     def get_beatmaps(self, *, since=None, beatmapset_id=None, beatmap_id=None, username=None, mode=None,

~/code/api/osuapi/osu.py in _make_req(self, endpoint, data, type_)
     29 
     30     def _make_req(self, endpoint, data, type_):
---> 31         return self.connector.process_request(endpoint, {k: v for k, v in data.items() if v is not None}, type_)
     32 
     33     def get_user(self, username, *, mode=OsuMode.osu, event_days=31):

~/code/api/osuapi/connectors.py in process_request(self, endpoint, data, type_, retries)
     90                     resp = self.sess.get(endpoint, params=data)
     91                     if resp.status_code == 200:
---> 92                         return type_(resp.json())
     93                     elif resp.status_code == 504 and retries:
     94                         retries -= 1

~/code/api/osuapi/dictmodel.py in _(lst)
     65     field = JsonList(int) would expect to be passed a list of things to convert to int"""
     66     def _(lst):
---> 67         return [oftype(entry) for entry in lst]
     68 
     69     return _

~/code/api/osuapi/dictmodel.py in <listcomp>(.0)
     65     field = JsonList(int) would expect to be passed a list of things to convert to int"""
     66     def _(lst):
---> 67         return [oftype(entry) for entry in lst]
     68 
     69     return _

~/code/api/osuapi/dictmodel.py in __init__(self, dct)
     49                 warnings.warn("Unknown attribute {} in API response for type {}".format(k, type(self)), Warning)
     50             else:
---> 51                 setattr(self, attr.field_name, attr.parse(v))
     52 
     53     def _iterator(self):

~/code/api/osuapi/dictmodel.py in parse(self, value)
     18 
     19     def parse(self, value):
---> 20         return self.type(value)
     21 
     22 

TypeError: float() argument must be a string or a number, not 'NoneType'
```