### PR TITLE
Properly convert Score.perfect to bool

### DIFF
--- a/osuapi/model.py
+++ b/osuapi/model.py
@@ -44,7 +44,7 @@ class Score(AttributeModel):
     countmiss = Attribute(int)
     countkatu = Attribute(int)
     countgeki = Attribute(int)
-    perfect = Attribute(bool)
+    perfect = Attribute(PreProcessInt(bool))
     user_id = Attribute(int)
     rank = Attribute(str)
 


### PR DESCRIPTION
Bug:

```python
>>> scores = api.get_scores(beatmap_id=129891, username='cookiezi')
>>> scores[1].score_id, scores[1].countmiss, scores[1].perfect
(2266240534, 1, True)
>>> scores = requests.get("https://osu.ppy.sh/api/get_scores?k=%s&u=cookiezi&b=129891" % os.environ["OSU_API_KEY"]).json()
>>> scores[1]["score_id"], scores[1]["countmiss"], scores[1]["perfect"]
('2266240534', '1', '0')
```

Reason:

```python
>>> bool("0")
True
```

As an aside, this code is really easy to work with :smile: 